### PR TITLE
fix: updated detect-secrets package version

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.1.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -77,6 +77,12 @@
       "path": "detect_secrets.filters.heuristic.is_likely_id_string"
     },
     {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_potential_uuid"
     },
     {
@@ -84,6 +90,9 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
@@ -96,5 +105,5 @@
     }
   ],
   "results": {},
-  "generated_at": "2021-04-04T17:44:30Z"
+  "generated_at": "2021-04-22T13:08:55Z"
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,7 +25,7 @@ name = "certifi"
 version = "2020.12.5"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -33,7 +33,7 @@ name = "chardet"
 version = "4.0.0"
 description = "Universal encoding detector for Python 2 and 3"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
@@ -60,7 +60,7 @@ name = "detect-secrets"
 version = "1.1.0"
 description = "Tool for detecting secrets in the codebase"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [package.dependencies]
@@ -76,7 +76,7 @@ name = "idna"
 version = "2.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -213,7 +213,7 @@ name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
@@ -221,7 +221,7 @@ name = "requests"
 version = "2.25.1"
 description = "Python HTTP for Humans."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
@@ -263,7 +263,7 @@ name = "urllib3"
 version = "1.26.4"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
@@ -277,7 +277,7 @@ dev = ["pytest", "pytest-cov", "pytest-dotenv", "mypy"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<4.0"
-content-hash = "c261a2340d931c560d72bd3b8b072857167c71dd318deaf7b64cedab5b3114fb"
+content-hash = "f5ad0f506861acc1d0509a270f4f50f8f03499655acadde5d19b709ce533657d"
 
 [metadata.files]
 atomicwrites = [
@@ -363,6 +363,7 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 mypy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ python = ">=3.8,<4.0"
 pytest = { version = "^6.1.1", optional = true }
 pytest-cov =  { version = "^2.10.1", optional = true }
 pytest-dotenv = { version = "^0.5.2", optional = true }
-detect-secrets = { version = "^1.0.3", optional = true }
 mypy = { version = "^0.812", optional = true }
+detect-secrets = {version = "^1.1.0", extras = ["dev"]}
 
 # package deps
 


### PR DESCRIPTION
With an old detect-secrets version I caught the error:

`[Errno 2] No such file or directory

at /usr/lib/python3.8/os.py:601 in _execvpe
     597│         path_list = map(fsencode, path_list)
     598│     for dir in path_list:
     599│         fullname = path.join(dir, file)
     600│         try:
  →  601│             exec_func(fullname, *argrest)
     602│         except (FileNotFoundError, NotADirectoryError) as e:
     603│             last_exc = e
     604│         except OSError as e:
     605│             last_exc = e`
     
     during generating .secrets.baseline
     I decided to upgrade the detect-secrets package to it's latest 1.1.0 version. And all is working now.
     Double-check it on your side and apply changes, please.